### PR TITLE
17 update instructions for development

### DIFF
--- a/docs/source/help/development.rst
+++ b/docs/source/help/development.rst
@@ -2,50 +2,107 @@
 Development
 ***********
 
-Install the development environment
-===================================
+Install the development environment with Docker
+===============================================
 
-If you want to try agilepy's new features that are not officially released yet, 
-a develpoment environment called agilepy-environment is available into Anaconda cloud. 
-It contains all the dependencies unless agilepy, which must be installed by hand cloning the repository.
+If you want to develop new agilepy features or try the newest yet unreleased ones,
+a development Docker image called agilepy-recipe is availabe on dockerhub.
+It contains all the dependencies but agilepy, which must be installed by hand by cloning the repository.
 
-Anaconda
---------
-::
+Agilepy's development containers can be found at dockerhub `agilescience/agilepy-recipe <https://hub.docker.com/repository/docker/agilescience/agilepy-recipe>`_ page,
+please check it for the latest tag.
 
-    
-    conda config --add channels conda-forge
-    conda config --add channels plotly
-    conda create -n agilepydev -c agilescience agiletools agilepy-dataset
-    conda activate agilepydev
-    git clone https://github.com/AGILESCIENCE/Agilepy.git
-    cd Agilepy && git checkout develop
-    conda env update -f environment.yml
-    python setup.py develop
+Instructions
+------------
 
-Docker
-------
+1. Prepare your workspace by creating a directory :code:`agile` at
+path :code:`$PATH_TO_AGILE`.
+It is going to be shared between your local file system tree and the developement container's one.
 
-::
+.. code-block::
 
-    docker pull agilescience/agilepy-recipe:latest
-    mkdir shared_dir && cd shared_dir && git clone https://github.com/AGILESCIENCE/Agilepy.git \
-    && cd Agilepy && git checkout develop
-    
-    docker run --rm -it -p 8888:8888 \
+    $ mkdir agile && cd agile
+
+2. Clone the GitHub Agilepy repository, switch to the development branch you are interested to work on
+(e.g. :code:`develop` or any other branch with a given feature).
+
+.. code-block::
+
+    $ git clone https://github.com/AGILESCIENCE/Agilepy.git && cd Agilepy
+    $ git switch develop
+
+3. Pull the development Docker image, replace :code:`<LATEST-TAG>` with the
+latest tag available at `agilepy-recipe/tags <https://hub.docker.com/r/agilescience/agilepy-recipe/tags>`_.
+
+.. code-block::
+
+    $ docker pull agilescience/agilepy-recipe:<LATEST-TAG>
+
+4. Build the Docker Container with name :code:`agilepy_dev` from the Docker Image.
+The following command binds port :code:`8888` of the container to port :code:`8090` of your local host,
+change it if already occupated.
+It shares the :code:`agile` directory between host and container.
+
+.. code-block::
+
+    $ docker run --rm -t -d -p 8090:8888 --name agilepy_dev \
     -e DISPLAY=$DISPLAY \
     -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
-    -v $SHARED_DIR_PATH:/shared_dir \
-    agilescience/agilepy-recipe:latest
-    
-    ## -- Inside the container --
-    conda activate agilepydev
-    cd /shared_dir/Agilepy python setup.py develop
-
-    jupyter notebook --port 8889 --ip 0.0.0.0  --allow-root
+    -v $PATH_TO_AGILE:/agile \
+    agilescience/agilepy-recipe:<LATEST-TAG>
 
 
-Now you have the agilepy's latest version installed in your environment.
+5. Enter container with:
+
+.. code-block::
+
+    $ docker exec -it agilepy_dev bash -l
+
+6. Inside the container activate virtual environment,
+move to repository location and install the code in *editable* mode:
+
+.. code-block::
+
+    $ source /opt/venv/agilepy/bin/activate
+    $ cd /agile/Agilepy
+    $ pip install -e .
+
+Now you have the agilepy's latest development version installed in your environment.
+You can also edit it to implement your own agilepy features!
+
+- When you need to exit the container just enter :code:`$ exit`.
+- To stop the container use
+
+.. code-block::
+
+    $ docker stop agilepy_dev
+
+- If you need to run a jupyter notebook you can run it in the binded port :code:`8888` from within the container. Take note of the token set by jupyter, search for **http://localhost:8090/** in your browser and insert the token. The command to run jupyter notebook is:
+
+::
+
+    $ jupyter notebook --port 8888 --ip 0.0.0.0  --allow-root
+
+.. note::
+
+    Currently the user inside the container is root.
+    Modifying files from within the container might change the user proprietary of the files in your local system too.
+    We suggest to modify files from *outside* the container with a text editor and use the container
+    to run your scripts.
+
+
+.. Anaconda
+.. --------
+.. ::
+..     conda config --add channels conda-forge
+..     conda config --add channels plotly
+..     conda create -n agilepydev -c agilescience agiletools agilepy-dataset
+..     conda activate agilepydev
+..     git clone https://github.com/AGILESCIENCE/Agilepy.git
+..     cd Agilepy && git checkout develop
+..     conda env update -f environment.yml
+..     python setup.py develop
+
 
 
 Git flow

--- a/docs/source/help/development.rst
+++ b/docs/source/help/development.rst
@@ -15,13 +15,14 @@ please check it for the latest tag.
 Instructions
 ------------
 
-1. Prepare your workspace by creating a directory :code:`agile` at
-path :code:`$PATH_TO_AGILE`.
-It is going to be shared between your local file system tree and the developement container's one.
+1. Prepare your workspace by creating a directory :code:`agile`
+and store its path in a variable :code:`$PATH_TO_AGILE`.
+The :code:`agile` directory is going to be shared between your local file system tree and the developement container's one.
 
 .. code-block::
 
     $ mkdir agile && cd agile
+    $ export PATH_TO_AGILE=$PWD
 
 2. Clone the GitHub Agilepy repository, switch to the development branch you are interested to work on
 (e.g. :code:`develop` or any other branch with a given feature).

--- a/docs/source/quickstart/installation.rst
+++ b/docs/source/quickstart/installation.rst
@@ -20,12 +20,6 @@ need to decide the name of the virtual environment that will be created by anaco
     conda config --add channels plotly
     conda create -n <virtualenv_name> -c agilescience agilepy
 
-.. note:: If you want to try agilepy's new features that are not officially released yet, 
-           a develpoment environment called agilepy-environment is available into Anaconda cloud. 
-           It contains all the dependencies unless agilepy, 
-           which must be installed by hand cloning the repository.
-           Check the installation instructions `here <../help/development.html#install-the-development-environment>`_
-
 Supported platforms:
 
   - linux-64
@@ -73,8 +67,12 @@ You can pull the image directly from dockerhub using the following command:
 
 .. note:: Check the installation instructions for Docker `here <https://docs.docker.com/get-docker/>`_
 
-.. note:: If you want to try agilepy’s new features that are not officially released yet, you need to
-          pull a develop image available using **agilepy:develop-latest** tag
+.. note:: The agilepy version installed inside the container cannot be modified.
+          If you want to try agilepy's new features that are not officially released yet,
+          you need to pull a development image called agilepy-recipe.
+          It contains all the dependencies but agilepy, 
+          which must be installed by hand by cloning the repository.
+          Check the `Development <../help/development.html>`_ page for installation instructions.
 
 
 Using this command you can launch the container and automatically start jupyter notebook.
@@ -94,7 +92,7 @@ shared_dir must be created before launching the command, it is not necessary, bu
 
 Jupyter server is at localhost:8888
 
-Agilepy's containers can be found at dockerhub `page <https://hub.docker.com/repository/docker/agilescience/agilepy>`_
+Agilepy's containers can be found at dockerhub `agilescience/agilepy <https://hub.docker.com/repository/docker/agilescience/agilepy>`_ page.
 
 Supported platforms:
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup( name='agilepy',
        version='1.6.3',
-       author='Baroncelli Leonardo, Addis Antonio, Bulgarelli Andrea, Parmiggiani Nicolò, Ambra Di Piano, Gabriele Panebianc',
+       author='Baroncelli Leonardo, Addis Antonio, Bulgarelli Andrea, Parmiggiani Nicolò, Ambra Di Piano, Gabriele Panebianco',
        author_email='leonardo.baroncelli@inaf.it, antonio.addis@inaf.it, andrea.bulgarelli@inaf.it, nicolo.parmiggiani@inaf.it, ambra.dipiano@inaf.it, gabriele.panebianco@inaf.it',
        packages=find_packages(),
        package_dir={ 'agilepy': 'agilepy' },

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup( name='agilepy',
-       version='1.6.2',
+       version='1.6.3',
        author='Baroncelli Leonardo, Addis Antonio, Bulgarelli Andrea, Parmiggiani Nicolò, Ambra Di Piano, Gabriele Panebianc',
        author_email='leonardo.baroncelli@inaf.it, antonio.addis@inaf.it, andrea.bulgarelli@inaf.it, nicolo.parmiggiani@inaf.it, ambra.dipiano@inaf.it, gabriele.panebianco@inaf.it',
        packages=find_packages(),


### PR DESCRIPTION
Update development instructions. Close #17 

In _docs/source/help/development.rst_ 

1.  Remove references to development with Anaconda. Development with anaconda used to be done with
    ```
    conda create -n agilepydev -c agilescience agiletools agilepy-dataset
    conda activate agilepydev
    conda env update -f environment.yml
    python setup.py develop
    ```
    I left this code as a comment inside development.rst if we ever need it again.

2. Update the Docker Development installation with step-by-step instructions.

Also update references to development in _docs/source/quickstart/installation.rst_ accordingly.

**IMPORTANT**

- [ ] In setup.py change agilepy version number 1.6.2 -> 1.6.3. I reckon we forgot to update it. Is it correct or should we change it back?